### PR TITLE
Copy navbar-content.html since render_site() deletes output directory.

### DIFF
--- a/navbar-content.html
+++ b/navbar-content.html
@@ -1,0 +1,24 @@
+<div class="navbar navbar-default  navbar-fixed-top" role="navigation">
+  <div class="container">
+    <div class="navbar-header">
+      <!-- NOTE: add "navbar-inverse" class for an alternate navbar background -->
+      <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#navbar">
+        <span class="icon-bar"></span>
+        <span class="icon-bar"></span>
+        <span class="icon-bar"></span>
+      </button>
+      <a class="navbar-brand" href="index.html">HTML Navbar</a>
+    </div>
+    <div id="navbar" class="navbar-collapse collapse">
+      <ul class="nav navbar-nav">
+        <li><a href="index.html">Home</a></li>
+      </ul>
+      <ul class="nav navbar-nav">
+        <li><a href="another-page.html">Another page</a></li>
+      </ul>
+      <ul class="nav navbar-nav navbar-right">
+        <li><a href="https://github.com">GitHub</a></li>
+      </ul>
+    </div><!--/.nav-collapse -->
+  </div><!--/.container -->
+</div><!--/.navbar -->


### PR DESCRIPTION
@lazappi Thanks again for creating this clever workaround and sharing it with me. I don't have much experience with jQuery, so I am learning a lot.

While I was playing around with it, I realized a limitation of your current setup is that building the entire website with `rmarkdown::render_site()` deletes the existing output directory. Thus `navbar-content.html` is lost. In this PR, I copied it to the root of the repo. `rmarkdown::render_site()` copies this to `docs/`.

Alternatively, if you don't like the duplication of `navbar-content.html`, another solution would be to advise always specifying a file, e.g. `rmarkdown::render_site("index.Rmd")`. Under the hood, this is the strategy that `wflow_build()` uses, so that any files the user manually adds to `docs/` are never affected.